### PR TITLE
Avoid providing stale files from cache

### DIFF
--- a/src/de/hahnjo/android/smbprovider/provider/SMBProvider.java
+++ b/src/de/hahnjo/android/smbprovider/provider/SMBProvider.java
@@ -76,11 +76,7 @@ public class SMBProvider extends DocumentsProvider {
 		Document document = fromLastChildQuery(documentId);
 		if (document != null) {
 			if (BuildConfig.DEBUG) Log.d(TAG, "The document " + documentId + " was in the last directory that was queried");
-			try {
-				return new DocumentCursor(projection, document);
-			} catch (SmbException e) {
-				Log.e(TAG, "Error occurred while retrieving information about a document", e);
-			}
+			return new DocumentCursor(projection, document);
 		}
 
 		return null;
@@ -93,12 +89,7 @@ public class SMBProvider extends DocumentsProvider {
 		final ChildQueryResult last = lastChildQueryResult; // thread-safe reference
 		final Cursor cursor;
 		if (last != null && parentDocumentId.equals(last.parent.documentId)) {
-			try {
-				cursor = new DocumentCursor(projection, last.childArray);
-			} catch (SmbException e) {
-				e.printStackTrace();
-				throw new FileNotFoundException( e.toString() );
-			}
+			cursor = new DocumentCursor(projection, last.childArray);
 		} else {
 			cursor = new ExtraLoadingCursor();
 			cursor.setNotificationUri(getContext().getContentResolver(), DocumentsContract.buildDocumentUri(AUTHORITY, parentDocumentId));

--- a/src/de/hahnjo/android/smbprovider/provider/cursor/DocumentCursor.java
+++ b/src/de/hahnjo/android/smbprovider/provider/cursor/DocumentCursor.java
@@ -4,7 +4,6 @@ import android.database.Cursor;
 import android.database.MatrixCursor;
 import android.provider.DocumentsContract;
 import de.hahnjo.android.smbprovider.provider.Document;
-import jcifs.smb.SmbException;
 
 /**
  * A {@link Cursor} that contains information about documents as specified by {@link DocumentsContract.Document}.
@@ -30,7 +29,7 @@ public class DocumentCursor extends MatrixCursor {
 	/**
 	 * Creates a cursor that is filled with one {@link Document}.
 	 */
-	public DocumentCursor(String[] projection, Document document) throws SmbException {
+	public DocumentCursor(String[] projection, Document document) {
 		this(projection);
 
 		addRow(document);
@@ -39,7 +38,7 @@ public class DocumentCursor extends MatrixCursor {
 	/**
 	 * Creates a cursor that is filled with multiple {@link Document}s.
 	 */
-	public DocumentCursor(String[] projection, Document[] documents) throws SmbException {
+	public DocumentCursor(String[] projection, Document[] documents) {
 		this(projection);
 
 		for (Document document : documents) {
@@ -50,7 +49,7 @@ public class DocumentCursor extends MatrixCursor {
 	/**
 	 * Adds a new row for this {@link Document}.
 	 */
-	protected void addRow(Document document) throws SmbException {
+	protected void addRow(Document document) {
 		newRow().add(DocumentsContract.Document.COLUMN_DISPLAY_NAME, document.name)
 			.add(DocumentsContract.Document.COLUMN_DOCUMENT_ID, document.documentId)
 			.add(DocumentsContract.Document.COLUMN_FLAGS, 0)

--- a/src/de/hahnjo/android/smbprovider/provider/cursor/DocumentCursor.java
+++ b/src/de/hahnjo/android/smbprovider/provider/cursor/DocumentCursor.java
@@ -2,6 +2,7 @@ package de.hahnjo.android.smbprovider.provider.cursor;
 
 import android.database.Cursor;
 import android.database.MatrixCursor;
+import android.os.Bundle;
 import android.provider.DocumentsContract;
 import de.hahnjo.android.smbprovider.provider.Document;
 
@@ -19,18 +20,25 @@ public class DocumentCursor extends MatrixCursor {
 		DocumentsContract.Document.COLUMN_SIZE
 	};
 
+	private final Bundle extras;
+
 	/**
 	 * Creates an empty cursor.
 	 */
 	public DocumentCursor(String[] projection) {
+		this(projection, Bundle.EMPTY);
+	}
+
+	private DocumentCursor(String[] projection, Bundle extras) {
 		super(projection == null ? DEFAULT_PROJECTION : projection);
+		this.extras = extras;
 	}
 
 	/**
 	 * Creates a cursor that is filled with one {@link Document}.
 	 */
 	public DocumentCursor(String[] projection, Document document) {
-		this(projection);
+		this(projection, Bundle.EMPTY);
 
 		addRow(document);
 	}
@@ -38,8 +46,8 @@ public class DocumentCursor extends MatrixCursor {
 	/**
 	 * Creates a cursor that is filled with multiple {@link Document}s.
 	 */
-	public DocumentCursor(String[] projection, Document[] documents) {
-		this(projection);
+	public DocumentCursor(String[] projection, Document[] documents, Bundle extras) {
+		this(projection,extras);
 
 		for (Document document : documents) {
 			addRow(document);
@@ -49,13 +57,18 @@ public class DocumentCursor extends MatrixCursor {
 	/**
 	 * Adds a new row for this {@link Document}.
 	 */
-	protected void addRow(Document document) {
+	private void addRow(Document document) {
 		newRow().add(DocumentsContract.Document.COLUMN_DISPLAY_NAME, document.name)
 			.add(DocumentsContract.Document.COLUMN_DOCUMENT_ID, document.documentId)
 			.add(DocumentsContract.Document.COLUMN_FLAGS, 0)
 			.add(DocumentsContract.Document.COLUMN_LAST_MODIFIED, document.lastModified)
 			.add(DocumentsContract.Document.COLUMN_MIME_TYPE, document.mimeType)
 			.add(DocumentsContract.Document.COLUMN_SIZE, document.size);
+	}
+
+	@Override
+	public Bundle getExtras() {
+		return extras;
 	}
 
 }

--- a/src/de/hahnjo/android/smbprovider/provider/cursor/ExtraLoadingCursor.java
+++ b/src/de/hahnjo/android/smbprovider/provider/cursor/ExtraLoadingCursor.java
@@ -12,7 +12,7 @@ import android.provider.DocumentsProvider;
  */
 public class ExtraLoadingCursor extends AbstractCursor {
 
-	private static final Bundle EXTRA_LOADING_BUNDLE = new Bundle();
+	public static final Bundle EXTRA_LOADING_BUNDLE = new Bundle();
 	static {
 		EXTRA_LOADING_BUNDLE.putBoolean(DocumentsContract.EXTRA_LOADING, true);
 	}


### PR DESCRIPTION
This corrects a problem where the client never sees modifications to a file, but only the stale contents from the old, cached copy.

Mike
